### PR TITLE
Explicitly map a remote ref to a local branch.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -39,7 +39,7 @@ fn checkout_mr(mr_id: i64) {
     info!("Getting MR: {}", mr_id);
     let mut remote = get_remote_hard(true);
     debug!("Found remote: {}", remote);
-    let branch_name = match remote.get_req_branch(mr_id) {
+    let remote_branch_name = match remote.get_remote_req_branch(mr_id) {
         Ok(name) => name,
         Err(error) => {
             eprintln!(
@@ -49,8 +49,11 @@ fn checkout_mr(mr_id: i64) {
             process::exit(1);
         }
     };
-    debug!("Got branch name: {}", branch_name);
-    match git::checkout_branch(&branch_name) {
+    debug!("Got remote branch name: {}", remote_branch_name);
+    match git::checkout_branch(
+        &remote_branch_name,
+        &remote.get_local_req_branch(mr_id).unwrap(),
+    ) {
         Ok(_) => {
             info!("Done!");
         }

--- a/src/remotes/github.rs
+++ b/src/remotes/github.rs
@@ -32,8 +32,12 @@ impl Remote for GitHub {
         Ok(&self.id)
     }
 
-    fn get_req_branch(&mut self, mr_id: i64) -> Result<String, &str> {
-        Ok(format!("pr/{}", mr_id))
+    fn get_local_req_branch(&mut self, mr_id: i64) -> Result<String, &str> {
+        Ok(format!("pr/{mr_id}", mr_id = mr_id))
+    }
+
+    fn get_remote_req_branch(&mut self, mr_id: i64) -> Result<String, &str> {
+        Ok(format!("pull/{mr_id}/head", mr_id = mr_id))
     }
 
     fn get_req_names(&mut self) -> Result<Vec<MergeRequest>, &str> {

--- a/src/remotes/gitlab.rs
+++ b/src/remotes/gitlab.rs
@@ -58,7 +58,11 @@ impl Remote for GitLab {
         Ok(&self.id)
     }
 
-    fn get_req_branch(&mut self, mr_id: i64) -> Result<String, &str> {
+    fn get_local_req_branch(&mut self, mr_id: i64) -> Result<String, &str> {
+        self.get_remote_req_branch(mr_id)
+    }
+
+    fn get_remote_req_branch(&mut self, mr_id: i64) -> Result<String, &str> {
         query_gitlab_branch_name(self, mr_id)
     }
 

--- a/src/remotes/mod.rs
+++ b/src/remotes/mod.rs
@@ -20,8 +20,11 @@ pub trait Remote {
     /// Get the ID of the project associated with the repository
     fn get_project_id(&mut self) -> Result<&str, &str>;
 
-    /// Get the branch associated with the merge request having the given ID
-    fn get_req_branch(&mut self, mr_id: i64) -> Result<String, &str>;
+    /// Get the local branch associated with the merge request having the given ID
+    fn get_local_req_branch(&mut self, mr_id: i64) -> Result<String, &str>;
+
+    /// Get the remote branch associated with the merge request having the given ID
+    fn get_remote_req_branch(&mut self, mr_id: i64) -> Result<String, &str>;
 
     /// Get the names of the merge/pull requests opened against the remote
     fn get_req_names(&mut self) -> Result<Vec<MergeRequest>, &str>;


### PR DESCRIPTION
This change allows us to use the same code paths for GitHub and GitLab,
and make this truly multi-DCVS.

Assuming remote MR/PR 13:

On GitLab, this should be unchanged:
* `GET 13` -> feat/foo-bar
* `git fetch origin feat/foo-bar:feat/foo-bar` -> (local ref) feat/foo-bar
* `git checkout feat/foo-bar`

On GitHub, one no longer needs to add the `pulls` refspec to the remote.  Instead:
* `FORMAT 13` -> pulls/13/head
* `git fetch origin pulls/13/head:pr/13` -> (local ref) pr/13
* `git checkout pr/13`

Fixes #19 