### PR TITLE
Add Homebrew Formula

### DIFF
--- a/pkg/brew/git-req.rb
+++ b/pkg/brew/git-req.rb
@@ -1,5 +1,5 @@
 class GitReq < Formula
-  desc "Check out merge requests from your GitLab/GitHub hosted repositories with ease!"
+  desc "Check out merge requests from GitLab/GitHub repositories with ease!"
   homepage "https://arusahni.github.io/git-req/"
   url "https://github.com/arusahni/git-req/archive/v2.1.0.tar.gz"
   sha256 "a7bc8f90230762e93d348dcb22dee93b7c47d07678012976a229950a752a72ff"

--- a/pkg/brew/git-req.rb
+++ b/pkg/brew/git-req.rb
@@ -1,0 +1,17 @@
+class GitReq < Formula
+  desc "Check out merge requests from your GitLab/GitHub hosted repositories with ease!"
+  homepage "https://arusahni.github.io/git-req/"
+  url "https://github.com/arusahni/git-req/archive/v2.1.0.tar.gz"
+  sha256 "a7bc8f90230762e93d348dcb22dee93b7c47d07678012976a229950a752a72ff"
+
+  depends_on "git" => :optional
+  depends_on "rust" => :build
+
+  def install
+    system "cargo", "install", "--root", prefix, "--path", "."
+  end
+
+  test do
+    assert_match /git-req 2.1.0/, shell_output("#{bin}/git-req --version")
+  end
+end

--- a/pkg/brew/git-req.rb
+++ b/pkg/brew/git-req.rb
@@ -4,7 +4,6 @@ class GitReq < Formula
   url "https://github.com/arusahni/git-req/archive/v2.1.0.tar.gz"
   sha256 "a7bc8f90230762e93d348dcb22dee93b7c47d07678012976a229950a752a72ff"
 
-  depends_on "git" => :optional
   depends_on "rust" => :build
 
   def install


### PR DESCRIPTION
Adds Homebrew package.

Builds using Brew's version of Rust, which is slow to install & builld, but follows the template used by most Rust-based tools I've found in Homebrew Core. Plan is to commit here as a single source of truth for now, then submit it to Homebrew Core, which will take care of bottling  binaries etc.

Part of #16 
Homebrew-core PR: https://github.com/Homebrew/homebrew-core/pull/44810