### PR TITLE
Fix clippy warning 'useless use of vec'

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -168,7 +168,7 @@ fn main() {
              .required(false)
              .takes_value(true))
         .group(ArgGroup::with_name("FLAGS")
-               .args(&vec!["NEW_PROJECT_ID", "LIST_MR", "CLEAR_PROJECT_ID", "CLEAR_DOMAIN_KEY"]))
+               .args(&["NEW_PROJECT_ID", "LIST_MR", "CLEAR_PROJECT_ID", "CLEAR_DOMAIN_KEY"]))
         .arg(Arg::with_name("REQUEST_ID")
              .required(true)
              .conflicts_with_all(&["FLAGS"])


### PR DESCRIPTION
Running `clippy` on the code base yields the following warning:

```
warning: useless use of `vec!`
   --> src/main.rs:171:22
    |
171 |                .args(&vec!["NEW_PROJECT_ID", "LIST_MR", "CLEAR_PROJECT_ID", "CLEAR_DOMAIN_KEY"]))
    |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: you can use a slice directly: `&["NEW_PROJECT_ID", "LIST_MR", "CLEAR_PROJECT_ID", "CLEAR_DOMAIN_KEY"]`
    |
    = note: `#[warn(clippy::useless_vec)]` on by default
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#useless_vec
```