### PR TITLE
Add support for different remote name

### DIFF
--- a/src/remotes/gitlab.rs
+++ b/src/remotes/gitlab.rs
@@ -185,9 +185,9 @@ fn search_gitlab_project_id(remote: &GitLab) -> Result<i64, &'static str> {
     }
 }
 
-/// Get the project ID from config
-pub fn load_project_id() -> Option<String> {
-    match git::get_config("projectid") {
+/// Get the project ID for the specified remote from config
+pub fn load_project_id(remote_name: &str) -> Option<String> {
+    match git::get_config("projectid", remote_name) {
         Some(project_id) => Some(project_id),
         None => {
             debug!("No project ID found");

--- a/src/remotes/mod.rs
+++ b/src/remotes/mod.rs
@@ -79,7 +79,11 @@ fn get_api_key(domain: &str) -> String {
 }
 
 /// Get a remote struct from an origin URL
-pub fn get_remote(origin: &str, skip_api_key: bool) -> Result<Box<dyn Remote>, String> {
+pub fn get_remote(
+    remote_name: &str,
+    origin: &str,
+    skip_api_key: bool,
+) -> Result<Box<dyn Remote>, String> {
     let domain = get_domain(origin)?;
     Ok(match domain {
         "github.com" => {
@@ -138,7 +142,7 @@ pub fn get_remote(origin: &str, skip_api_key: bool) -> Result<Box<dyn Remote>, S
                 info!("API Key: {}", &apikey);
                 remote.api_key = apikey;
             }
-            let project_id = match gitlab::load_project_id() {
+            let project_id = match gitlab::load_project_id(remote_name) {
                 Some(x) => x,
                 None => {
                     if skip_api_key {
@@ -151,7 +155,7 @@ pub fn get_remote(origin: &str, skip_api_key: bool) -> Result<Box<dyn Remote>, S
                                 Err(e)
                             }
                         }?;
-                        git::set_config("projectid", project_id_str);
+                        git::set_config("projectid", remote_name, project_id_str);
                         String::from(project_id_str)
                     }
                 }


### PR DESCRIPTION
Add a `use-remote` flag to try pulling the PR from a remote that is not the origin.

This solves part of the features on #22.