### PR TITLE
Shell completions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -521,6 +521,7 @@ dependencies = [
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "shellexpand 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tabwriter 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "yaml-rust 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "yaml-rust 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ tabwriter = "1"
 color-backtrace = "0.2"
 colored = "1.8"
 reqwest = {version = "0.9.9", default-features = false,  features = ['rustls-tls']}
+yaml-rust = "0.3.5"  # Using the same version that clap pushes for type compatibility
 
 [build-dependencies]
 man = "0.3.0"

--- a/README.md
+++ b/README.md
@@ -63,6 +63,34 @@ property.
 To clear the project ID: `git req --clear-project-id`
 To change the project ID: `git req --set-project-id PROJECT_ID`
 
+
+Completions
+-----------
+
+Completions are available for ZShell, Bash, and Fish shells.
+
+**ZShell**
+
+```bash
+git req --completions zsh > /path/to/zfunc/location/_git-req
+rm ~/.zcompdump
+exec zsh
+```
+
+**Bash**
+
+```bash
+git req --completions bash > git-req-completions.sh
+source git-req-completions.sh  # add this to your .bashrc!
+```
+
+**Fish**
+
+```bash
+git req --completions fish > git-req-completions.fish
+source git-req-completions.fish
+```
+
 Contributing
 ------------
 

--- a/cli-flags.yml
+++ b/cli-flags.yml
@@ -8,28 +8,60 @@ args:
       help: List all open requests against the repository
       takes_value: false
       required: false
+      conflicts_with:
+        - NEW_PROJECT_ID
+        - CLEAR_PROJECT_ID
+        - NEW_DOMAIN_KEY
+        - CLEAR_DOMAIN_KEY
+        - GENERATE_COMPLETIONS
   - NEW_PROJECT_ID:
       long: set-project-id
       value_name: PROJECT_ID
       help: Set a project ID for the current repository
       takes_value: true
       required: false
+      conflicts_with:
+        - CLEAR_PROJECT_ID
+        - NEW_DOMAIN_KEY
+        - CLEAR_DOMAIN_KEY
+        - GENERATE_COMPLETIONS
   - CLEAR_PROJECT_ID:
       long: clear-project-id
       help: Clear the project ID for the current repository
       takes_value: false
       required: false
+      conflicts_with:
+        - NEW_DOMAIN_KEY
+        - CLEAR_DOMAIN_KEY
+        - GENERATE_COMPLETIONS
   - NEW_DOMAIN_KEY:
       long: set-domain-key
       value_name: DOMAIN_KEY
       help: Set the API key for the current repository's domain
       takes_value: true
       required: false
+      conflicts_with:
+        - CLEAR_DOMAIN_KEY
+        - GENERATE_COMPLETIONS
   - CLEAR_DOMAIN_KEY:
       long: clear-domain-key
       help: Clear the API key for the current repository's domain
       takes_value: false
       required: false
+      conflicts_with:
+        - GENERATE_COMPLETIONS
+  - GENERATE_COMPLETIONS:
+      long: completions
+      help: Generate a shell completion file
+      takes_value: true
+      possible_values:
+        - bash
+        - fish
+        - zsh
+      value_name: SHELL_NAME
+      required: false
+      conflicts_with:
+        - REMOTE_NAME
   - REMOTE_NAME:
       short: u
       long: use-remote
@@ -37,11 +69,19 @@ args:
       takes_value: true
       required: false
   - REQUEST_ID:
+      help: the ID of the MR or PR
+      takes_value: true
+      required_unless_one:
+        - NEW_PROJECT_ID
+        - CLEAR_PROJECT_ID
+        - NEW_DOMAIN_KEY
+        - CLEAR_DOMAIN_KEY
+        - LIST_MR
+        - GENERATE_COMPLETIONS
       conflicts_with:
         - NEW_PROJECT_ID
         - CLEAR_PROJECT_ID
         - NEW_DOMAIN_KEY
         - CLEAR_DOMAIN_KEY
         - LIST_MR
-      required: true
-      index: 1
+        - GENERATE_COMPLETIONS

--- a/cli-flags.yml
+++ b/cli-flags.yml
@@ -36,7 +36,6 @@ args:
       help: Specify the remote to be used
       takes_value: true
       required: false
-      default_value: origin
   - REQUEST_ID:
       conflicts_with:
         - NEW_PROJECT_ID

--- a/git-req-completion.bash
+++ b/git-req-completion.bash
@@ -1,6 +1,0 @@
-_git_req() {
-	local cur
-    _init_completion || return
-    COMPREPLY=( $(compgen -W '-l --list --set-project-id --clear-project-id --set-domain-key --clear-domain-key -u --use-remote' -- "$cur") )
-} &&
-complete -F _git_req git-req

--- a/src/main.rs
+++ b/src/main.rs
@@ -166,7 +166,8 @@ fn main() {
         .author(crate_authors!("\n"))
         .get_matches();
 
-    let remote_name = matches.value_of("REMOTE_NAME").unwrap();
+    // Not using Clap's default_value because of https://github.com/clap-rs/clap/issues/1140
+    let remote_name = matches.value_of("REMOTE_NAME").unwrap_or("origin");
 
     if let Some(project_id) = matches.value_of("NEW_PROJECT_ID") {
         set_project_id(remote_name, project_id);


### PR DESCRIPTION
This adds a `--completions` arg which, when supplied with one of `zsh`, `bash`, `fish`. It will invoke Clap's completion generation function to make a script which can then be loaded by a shell to supply completions for `git-req`.

I also changed `REQUEST_ID` to not use a `default_value` due to an issue with Clap's usage definition: https://github.com/clap-rs/clap/issues/1140

Fixes #35 