### PR TITLE
Ensure GitLab branches retain tracking information

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -63,6 +63,7 @@ fn checkout_mr(remote_name: &str, mr_id: i64) {
         remote_name,
         &remote_branch_name,
         &remote.get_local_req_branch(mr_id).unwrap(),
+        remote.has_virtual_remote_branch_names(),
     ) {
         Ok(_) => {
             info!("Done!");

--- a/src/remotes/github.rs
+++ b/src/remotes/github.rs
@@ -47,6 +47,10 @@ impl Remote for GitHub {
     fn has_useful_branch_names(&mut self) -> bool {
         false
     }
+
+    fn has_virtual_remote_branch_names(&mut self) -> bool {
+        true
+    }
 }
 
 /// Convert a GitHub PR to a git-req MergeRequest

--- a/src/remotes/gitlab.rs
+++ b/src/remotes/gitlab.rs
@@ -73,6 +73,10 @@ impl Remote for GitLab {
     fn has_useful_branch_names(&mut self) -> bool {
         true
     }
+
+    fn has_virtual_remote_branch_names(&mut self) -> bool {
+        false
+    }
 }
 
 /// Query the GitLab API

--- a/src/remotes/mod.rs
+++ b/src/remotes/mod.rs
@@ -32,6 +32,11 @@ pub trait Remote {
     /// Determine if the branch names are useful to display
     fn has_useful_branch_names(&mut self) -> bool;
 
+    /// If the remote branch is a namespaced ref instead of an actual branch
+    // This is useful for GitHub's `pull/mr/head` refs, where they're read-only
+    fn has_virtual_remote_branch_names(&mut self) -> bool;
+
+    /// The domain that hosts the remote
     fn get_domain(&mut self) -> &str;
 }
 


### PR DESCRIPTION
Prior to this change, GitLab branches were not checked out in such a way
that git recorded an upstream ref to track. Since there was no tracking info,
`git pull` no longer worked.  This commit updates this so the remote
branch is first fetched, and then the local branch is explicitly checked
out as tracking the remote one.

    git fetch origin my-mr-branch
    git checkout -b my-mr-branch origin/my-mr-branch

For GitHub, the existing method has been preserved as the namespace refs
the service makes available are read-only.  Tracking isn't available
with this method.

    git fetch origin pull/1337/head:pr/1337
    git checkout pr/1337

I don't think GitHub makes that available (see:
https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/checking-out-pull-requests-locally)

Fixes #43 