### PR TITLE
User-definable default remote support

### DIFF
--- a/cli-flags.yml
+++ b/cli-flags.yml
@@ -13,6 +13,7 @@ args:
         - CLEAR_PROJECT_ID
         - NEW_DOMAIN_KEY
         - CLEAR_DOMAIN_KEY
+        - NEW_DEFAULT_REMOTE
         - GENERATE_COMPLETIONS
   - NEW_PROJECT_ID:
       long: set-project-id
@@ -24,6 +25,7 @@ args:
         - CLEAR_PROJECT_ID
         - NEW_DOMAIN_KEY
         - CLEAR_DOMAIN_KEY
+        - NEW_DEFAULT_REMOTE
         - GENERATE_COMPLETIONS
   - CLEAR_PROJECT_ID:
       long: clear-project-id
@@ -33,6 +35,7 @@ args:
       conflicts_with:
         - NEW_DOMAIN_KEY
         - CLEAR_DOMAIN_KEY
+        - NEW_DEFAULT_REMOTE
         - GENERATE_COMPLETIONS
   - NEW_DOMAIN_KEY:
       long: set-domain-key
@@ -42,11 +45,20 @@ args:
       required: false
       conflicts_with:
         - CLEAR_DOMAIN_KEY
+        - NEW_DEFAULT_REMOTE
         - GENERATE_COMPLETIONS
   - CLEAR_DOMAIN_KEY:
       long: clear-domain-key
       help: Clear the API key for the current repository's domain
       takes_value: false
+      required: false
+      conflicts_with:
+        - NEW_DEFAULT_REMOTE
+        - GENERATE_COMPLETIONS
+  - NEW_DEFAULT_REMOTE:
+      long: set-default-remote
+      help: Set the name of the default remote for the repository
+      takes_value: true
       required: false
       conflicts_with:
         - GENERATE_COMPLETIONS
@@ -77,6 +89,7 @@ args:
         - NEW_DOMAIN_KEY
         - CLEAR_DOMAIN_KEY
         - LIST_MR
+        - NEW_DEFAULT_REMOTE
         - GENERATE_COMPLETIONS
       conflicts_with:
         - NEW_PROJECT_ID
@@ -84,4 +97,5 @@ args:
         - NEW_DOMAIN_KEY
         - CLEAR_DOMAIN_KEY
         - LIST_MR
+        - NEW_DEFAULT_REMOTE
         - GENERATE_COMPLETIONS

--- a/src/git.rs
+++ b/src/git.rs
@@ -154,7 +154,7 @@ pub fn checkout_branch(
         Some(default_remote_name) => {
             if remote_name != default_remote_name {
                 trace!("Non-default remote name requested: {}", remote_name);
-                format!("{}/{}", remote_name, local_branch_name)
+                format!("req/{}/{}", remote_name, local_branch_name)
             } else {
                 trace!("Default remote name requested: {}", remote_name);
                 String::from(local_branch_name)

--- a/src/git.rs
+++ b/src/git.rs
@@ -28,8 +28,12 @@ fn slugify_domain(domain: &str) -> String {
 pub fn get_remotes() -> HashSet<String> {
     let repo = Repository::open_from_env().expect("Couldn't find repository");
     match repo.remotes() {
-        Ok(remotes) => remotes.into_iter().filter_map(|rem| rem).map(|rem| String::from(rem)).collect(),
-        Err(_) => HashSet::new()
+        Ok(remotes) => remotes
+            .into_iter()
+            .filter_map(|rem| rem)
+            .map(String::from)
+            .collect(),
+        Err(_) => HashSet::new(),
     }
 }
 
@@ -89,8 +93,7 @@ pub fn get_project_config(field_name: &str) -> Option<String> {
 pub fn set_project_config(field_name: &str, value: &str) {
     let repo = Repository::open_from_env().expect("Couldn't find repository");
     let mut cfg = repo.config().unwrap();
-    cfg.set_str(&format!("req.{}", field_name), value)
-        .unwrap();
+    cfg.set_str(&format!("req.{}", field_name), value).unwrap();
 }
 
 /// Get a value for the given global git-req config
@@ -161,10 +164,7 @@ pub fn checkout_branch(
             }
         }
         None => {
-            warn!(
-                "No default remote found. Using {}",
-                remote_name
-            );
+            warn!("No default remote found. Using {}", remote_name);
             format!("{}/{}", remote_name, local_branch_name)
         }
     };

--- a/src/main.rs
+++ b/src/main.rs
@@ -128,6 +128,13 @@ fn set_project_id(remote_name: &str, new_id: &str) {
     eprintln!("{}", "New project ID set!".green());
 }
 
+/// Set the default remote for the repository
+fn set_default_remote(remote_name: &str) {
+    trace!("Setting default remote {}", remote_name);
+    git::set_project_config("defaultremote", remote_name);
+    eprintln!("{}", "New default remote set!".green());
+}
+
 /// Print the open requests
 fn list_open_requests(remote_name: &str) {
     info!("Getting open requests");
@@ -178,7 +185,9 @@ fn get_remote_name(matches: &ArgMatches) -> String {
                     }
                     print!("Remote name: ");
                     let _ = stdout().flush();
-                    stdin().read_line(&mut new_remote_name).expect("Did not input a name");
+                    stdin()
+                        .read_line(&mut new_remote_name)
+                        .expect("Did not input a name");
                     trace!("New remote: {}", &new_remote_name);
                     if !git::get_remotes().contains(new_remote_name.trim()) {
                         panic!("Invalid remote name provided")
@@ -191,7 +200,11 @@ fn get_remote_name(matches: &ArgMatches) -> String {
         }
     };
     // Not using Clap's default_value because of https://github.com/clap-rs/clap/issues/1140
-    String::from(matches.value_of("REMOTE_NAME").unwrap_or(&default_remote_name))
+    String::from(
+        matches
+            .value_of("REMOTE_NAME")
+            .unwrap_or(&default_remote_name),
+    )
 }
 
 fn build_cli(cfg: &yaml_rust::Yaml) -> App {
@@ -223,6 +236,8 @@ fn main() {
         clear_domain_key(&get_remote_name(&matches));
     } else if let Some(domain_key) = matches.value_of("NEW_DOMAIN_KEY") {
         set_domain_key(&get_remote_name(&matches), domain_key);
+    } else if let Some(remote_name) = matches.value_of("NEW_DEFAULT_REMOTE") {
+        set_default_remote(remote_name);
     } else if let Some(shell_name) = matches.value_of("GENERATE_COMPLETIONS") {
         let mut app = build_cli(&cfg);
         generate_completion(&mut app, &shell_name);


### PR DESCRIPTION
This adds:

* Project config-stored default remote names
* The ability for users to specify the default remote if one can't be inferred.
* A CLI flag for modifying the configured default remote
* Adding a `req/` prefix to non-default branch names
   * This is intended to avoid Git getting confused if it sees a known origin name as the first segment of a ref.

Fixes #22 