### PR TITLE
Nested project detection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,16 +28,16 @@ version = "0.6.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81ce3d38065e618af2d7b77e10c5ad9a069859b4be3c2250f674af3840d9c8a5"
 dependencies = [
- "memchr 2.2.0",
+ "memchr 2.3.4",
 ]
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.3"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6f484ae0c99fec2e858eb6134949117399f222608d84cadb3f58c1f97c2364c"
+checksum = "7404febffaa47dac81aa44dba71523c9d069b1bdc50a77db41195149e17f68e5"
 dependencies = [
- "memchr 2.2.0",
+ "memchr 2.3.4",
 ]
 
 [[package]]
@@ -159,7 +159,7 @@ dependencies = [
  "peeking_take_while",
  "proc-macro2 0.3.5",
  "quote 0.5.2",
- "regex 1.1.6",
+ "regex 1.3.9",
  "which",
 ]
 
@@ -374,7 +374,7 @@ dependencies = [
  "atty",
  "humantime",
  "log",
- "regex 1.1.6",
+ "regex 1.3.9",
  "termcolor",
 ]
 
@@ -458,6 +458,7 @@ dependencies = [
  "colored",
  "duct",
  "env_logger",
+ "git-url-parse",
  "git2",
  "lazy_static",
  "log",
@@ -471,6 +472,20 @@ dependencies = [
  "ureq",
  "yaml-rust 0.3.5",
  "yaml-rust 0.4.5",
+]
+
+[[package]]
+name = "git-url-parse"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49cb753e769f4a7dbf24d8973b378dabfc590b7d6f046d6541dbbc699a885506"
+dependencies = [
+ "anyhow",
+ "log",
+ "regex 1.3.9",
+ "strum",
+ "strum_macros",
+ "url 2.1.1",
 ]
 
 [[package]]
@@ -501,6 +516,15 @@ dependencies = [
  "log",
  "plain",
  "scroll",
+]
+
+[[package]]
+name = "heck"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87cbf45460356b7deeb5e3415b5563308c0a9b057c85e12b06ad551f98d0a6ac"
+dependencies = [
+ "unicode-segmentation",
 ]
 
 [[package]]
@@ -651,9 +675,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.2.0"
+version = "2.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2efc7bc57c883d4a4d6e3246905283d8dae951bb3bd32f49d6ef297f546e1c39"
+checksum = "0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525"
 
 [[package]]
 name = "memmap"
@@ -970,23 +994,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9329abc99e39129fcceabd24cf5d85b4671ef7c29c50e972bc5afe32438ec384"
 dependencies = [
  "aho-corasick 0.6.10",
- "memchr 2.2.0",
+ "memchr 2.3.4",
  "regex-syntax 0.5.6",
- "thread_local",
+ "thread_local 0.3.6",
  "utf8-ranges",
 ]
 
 [[package]]
 name = "regex"
-version = "1.1.6"
+version = "1.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f0a0bcab2fd7d1d7c54fa9eae6f43eddeb9ce2e7352f8518a814a4f65d60c58"
+checksum = "9c3780fcf44b193bc4d09f36d2a3c87b251da4a046c87795a0d35f4f927ad8e6"
 dependencies = [
- "aho-corasick 0.7.3",
- "memchr 2.2.0",
- "regex-syntax 0.6.6",
- "thread_local",
- "utf8-ranges",
+ "aho-corasick 0.7.15",
+ "memchr 2.3.4",
+ "regex-syntax 0.6.22",
+ "thread_local 1.1.0",
 ]
 
 [[package]]
@@ -1000,12 +1023,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.6"
+version = "0.6.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcfd8681eebe297b81d98498869d4aae052137651ad7b96822f09ceb690d0a96"
-dependencies = [
- "ucd-util",
-]
+checksum = "b5eb417147ba9860a96cfe72a0b93bf88fee1744b5636ec99ab20c1aa9376581"
 
 [[package]]
 name = "rgb"
@@ -1261,6 +1281,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
+name = "strum"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57bd81eb48f4c437cadc685403cad539345bf703d78e63707418431cecd4522b"
+
+[[package]]
+name = "strum_macros"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87c85aa3f8ea653bfd3ddf25f7ee357ee4d204731f6aa9ad04002306f6e2774c"
+dependencies = [
+ "heck",
+ "proc-macro2 1.0.9",
+ "quote 1.0.3",
+ "syn 1.0.17",
+]
+
+[[package]]
 name = "syn"
 version = "0.15.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1354,6 +1392,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb9bc092d0d51e76b2b19d9d85534ffc9ec2db959a2523cdae0697e2972cd447"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "time"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1413,6 +1460,12 @@ checksum = "141339a08b982d942be2ca06ff8b076563cbe223d1befd5450716790d44e2426"
 dependencies = [
  "smallvec",
 ]
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0d2e7be6ae3a5fa87eed5fb451aff96f2573d2694942e40543ae0bbe19c796"
 
 [[package]]
 name = "unicode-width"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ color-backtrace = "0.2"
 colored = "1.8"
 ureq = {version = "0.12.0", features = ["json"]}
 yaml-rust = "0.3.5"  # Using the same version that clap pushes for type compatibility
+git-url-parse = "0.3"
 anyhow = "1.0"
 
 [build-dependencies]

--- a/src/remotes/mod.rs
+++ b/src/remotes/mod.rs
@@ -126,11 +126,18 @@ pub fn get_remote(remote_name: &str, origin: &str, skip_api_key: bool) -> Result
                     ));
                 }
             };
+            let full_path = match gitlab::get_gitlab_project_full_path(origin) {
+                Some(full_path) => full_path,
+                None => {
+                    return Err(anyhow!("Could not parse the GitLab path from the origin."));
+                }
+            };
             let mut remote = gitlab::GitLab {
                 id: String::from(""),
                 domain: String::from(gitlab_domain),
                 name,
                 namespace,
+                full_path,
                 origin: String::from(origin),
                 api_root: format!("https://{}/api/v4", gitlab_domain),
                 api_key: String::from(""),


### PR DESCRIPTION
This improves the project ID detection method in two ways:

1. Switch from regexes to `parse-git-url`. This fixes an issue where the detected project/namespace was always the segment preceding the project name.
2. Use the full project path when attempting direct project lookup.

I'm going to keep this open for a few days for some real-world testing.

Fixes #51 