### PR TITLE
Add handling for GitHub API 401 errors

### DIFF
--- a/src/remotes/github.rs
+++ b/src/remotes/github.rs
@@ -87,10 +87,11 @@ fn retrieve_github_project_pull_requests(remote: &GitHub) -> Result<Vec<MergeReq
         }
         Err(response) => {
             debug!("Failed PR list query response: {:?}", response);
-            if response.status() == 404 {
-                return Err(anyhow!("remote project not found"));
-            }
-            return Err(anyhow!("failed to read API response"));
+            return match response.status() {
+                401 => Err(anyhow!("API unauthorized")),
+                404 => Err(anyhow!("remote project not found")),
+                _ => Err(anyhow!("failed to read API response")),
+            };
         }
     };
     Ok(gprs.into_iter().map(github_to_mr).collect())


### PR DESCRIPTION
Previously git-req was swallowing 401 status codes. This should make it easier to debug.